### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,19 @@
 
 This repository provide [DDEV](https://ddev.readthedocs.io) add-on for a Microsoft SQL Server 2019 db.
 
-In DDEV addons can be installed from the command line using the `ddev get` command, for example, `ddev get ddev/ddev-db-mssql`.
+In DDEV addons can be installed from the command line.
+
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get ddev/ddev-db-mssql
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get ddev/ddev-db-mssql
+```
 
 ## Thanks to
 
@@ -26,7 +38,7 @@ this repo provide a:
 
 ## Getting started
 
-1. add the add-on to your [DDEV](https://ddev.readthedocs.io) project using `ddev get ddev/ddev-db-mssql`
+1. add the add-on to your [DDEV](https://ddev.readthedocs.io) project using `ddev add-on get ddev/ddev-db-mssql` (or `ddev get ddev/ddev-db-mssql` for older versions of DDEV)
 2. restart with `ddev restart`
 3. please wait for the build of the updated `web-build`
 4. add a simple test PHP like the MS provided for [Testing Your Installation](https://learn.microsoft.com/en-us/sql/connect/php/installation-tutorial-linux-mac?view=sql-server-ver16) replacing the `${DDEV_SITENAME}` from your project


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.